### PR TITLE
Make sure Minio ddev plugin can work with default GitHub Actions Runner

### DIFF
--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -44,7 +44,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.5"
+          cpus: "2.0"
           memory: "1024M"
         reservations:
           cpus: "1.5"


### PR DESCRIPTION
To not duplicate the description - please read the details here the https://github.com/ddev/github-action-setup-ddev/issues/36